### PR TITLE
ci: Bump change-files action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v41
+      uses: tj-actions/changed-files@v46
       with:
         dir_names: "true"
         escape_json: "false"


### PR DESCRIPTION
There was a Malicious Commit introduced to tj-actions/changed-files action. It output secrets to stdout.
While the commit was removed it is still recommended to use the latest version of the action, hence bumping the version
https://github.com/tj-actions/changed-files/issues/2463#issuecomment-2727015784